### PR TITLE
Change ADR[18:0] to ADR[17:0]

### DIFF
--- a/examples/alternate/chip.v
+++ b/examples/alternate/chip.v
@@ -22,7 +22,7 @@ module chip (
     input DONE, // could be used as interupt in post programming
     input DBG1, // Could be used to select coms via STM32 or RPi etc..
     // SRAM Memory lines
-    output [18:0] ADR,
+    output [17:0] ADR,
     output [15:0] DAT,
     output RAMOE,
     output RAMWE,
@@ -36,7 +36,7 @@ module chip (
   );
 
   // SRAM signals are not use in this design, lets set them to default values
-  assign ADR[18:0] = {19{1'bz}};
+  assign ADR[17:0] = {18{1'bz}};
   assign DAT[15:0] = {16{1'bz}};
   assign RAMOE = 1'b1;
   assign RAMWE = 1'b1;

--- a/examples/blink/chip.v
+++ b/examples/blink/chip.v
@@ -21,7 +21,7 @@ module chip (
     input DONE, // could be used as interupt in post programming
     input DBG1, // Could be used to select coms via STM32 or RPi etc..
     // SRAM Memory lines
-    output [18:0] ADR,
+    output [17:0] ADR,
     output [15:0] DAT,
     output RAMOE,
     output RAMWE,
@@ -35,7 +35,7 @@ module chip (
   );
 
   // SRAM signals are not use in this design, lets set them to default values
-  assign ADR[18:0] = {19{1'bz}};
+  assign ADR[17:0] = {18{1'bz}};
   assign DAT[15:0] = {16{1'bz}};
   assign RAMOE = 1'b1;
   assign RAMWE = 1'b1;

--- a/examples/button/chip.v
+++ b/examples/button/chip.v
@@ -22,7 +22,7 @@ module chip (
     input DONE, // could be used as interupt in post programming
     input DBG1, // Could be used to select coms via STM32 or RPi etc..
     // SRAM Memory lines
-    output [18:0] ADR,
+    output [17:0] ADR,
     output [15:0] DAT,
     output RAMOE,
     output RAMWE,
@@ -36,7 +36,7 @@ module chip (
   );
 
   // SRAM signals are not use in this design, lets set them to default values
-  assign ADR[18:0] = {19{1'bz}};
+  assign ADR[17:0] = {18{1'bz}};
   assign DAT[15:0] = {16{1'bz}};
   assign RAMOE = 1'b1;
   assign RAMWE = 1'b1;

--- a/examples/count/chip.v
+++ b/examples/count/chip.v
@@ -22,7 +22,7 @@ module chip (
     input DONE, // could be used as interupt in post programming
     input DBG1, // Could be used to select coms via STM32 or RPi etc..
     // SRAM Memory lines
-    output [18:0] ADR,
+    output [17:0] ADR,
     output [15:0] DAT,
     output RAMOE,
     output RAMWE,
@@ -36,7 +36,7 @@ module chip (
   );
 
   // SRAM signals are not use in this design, lets set them to default values
-  assign ADR[18:0] = {19{1'bz}};
+  assign ADR[17:0] = {18{1'bz}};
   assign DAT[15:0] = {16{1'bz}};
   assign RAMOE = 1'b1;
   assign RAMWE = 1'b1;

--- a/examples/position/chip.v
+++ b/examples/position/chip.v
@@ -21,7 +21,7 @@ module chip (
     input DONE, // could be used as interupt in post programming
     input DBG1, // Could be used to select coms via STM32 or RPi etc..
     // SRAM Memory lines
-    output [18:0] ADR,
+    output [17:0] ADR,
     output [15:0] DAT,
     output RAMOE,
     output RAMWE,
@@ -35,7 +35,7 @@ module chip (
   );
 
   // SRAM signals are not use in this design, lets set them to default values
-  assign ADR[18:0] = {19{1'bz}};
+  assign ADR[17:0] = {18{1'bz}};
   assign DAT[15:0] = {16{1'bz}};
   assign RAMOE = 1'b1;
   assign RAMWE = 1'b1;

--- a/examples/random/chip.v
+++ b/examples/random/chip.v
@@ -22,7 +22,7 @@ module chip (
     input DONE, // could be used as interupt in post programming
     input DBG1, // Could be used to select coms via STM32 or RPi etc..
     // SRAM Memory lines
-    output [18:0] ADR,
+    output [17:0] ADR,
     output [15:0] DAT,
     output RAMOE,
     output RAMWE,
@@ -36,7 +36,7 @@ module chip (
   );
 
   // SRAM signals are not use in this design, lets set them to default values
-  assign ADR[18:0] = {19{1'bz}};
+  assign ADR[17:0] = {18{1'bz}};
   assign DAT[15:0] = {16{1'bz}};
   assign RAMOE = 1'b1;
   assign RAMWE = 1'b1;

--- a/examples/rotate/chip.v
+++ b/examples/rotate/chip.v
@@ -22,7 +22,7 @@ module chip (
     input DONE, // could be used as interupt in post programming
     input DBG1, // Could be used to select coms via STM32 or RPi etc..
     // SRAM Memory lines
-    output [18:0] ADR,
+    output [17:0] ADR,
     output [15:0] DAT,
     output RAMOE,
     output RAMWE,
@@ -36,7 +36,7 @@ module chip (
   );
 
   // SRAM signals are not use in this design, lets set them to default values
-  assign ADR[18:0] = {19{1'bz}};
+  assign ADR[17:0] = {18{1'bz}};
   assign DAT[15:0] = {16{1'bz}};
   assign RAMOE = 1'b1;
   assign RAMWE = 1'b1;


### PR DESCRIPTION
I ran into the same issue as the one described here:
https://forum.mystorm.uk/t/blackice-ii-pcf-adr-18-error/351

This patch changes all ADR[18:0] to ADR[17:0], after which the compilation issues are gone.

Right now, I only checked in the chip.v file.

Should I add the other post-compile files as well?